### PR TITLE
Adds ability to set square buttons without constructor.

### DIFF
--- a/THPinViewController/THPinViewController.h
+++ b/THPinViewController/THPinViewController.h
@@ -41,6 +41,7 @@ static const NSInteger THPinViewControllerContentViewTag = 14742;
 @property (nonatomic, strong) UIColor *promptColor;
 @property (nonatomic, assign) BOOL hideLetters; // hides the letters on the number buttons
 @property (nonatomic, assign) BOOL disableCancel; // hides the cancel button
+@property (nonatomic, assign) BOOL squareButtons; // makes the number buttons square if YES
 
 - (instancetype)initWithDelegate:(id<THPinViewControllerDelegate>)delegate squareButtons:(BOOL)squareButtons NS_DESIGNATED_INITIALIZER;
 

--- a/THPinViewController/THPinViewController.m
+++ b/THPinViewController/THPinViewController.m
@@ -15,7 +15,6 @@
 @property (nonatomic, strong) THPinView *pinView;
 @property (nonatomic, strong) UIView *blurView;
 @property (nonatomic, strong) NSArray *blurViewContraints;
-@property (nonatomic, assign) BOOL squareButtons; // makes the number buttons square if YES
 
 @end
 
@@ -143,6 +142,15 @@
     _disableCancel = disableCancel;
     self.pinView.disableCancel = self.disableCancel;
 }
+
+- (void)setSquareButtons:(BOOL)squareButtons
+{
+    if (self.squareButtons == squareButtons) {
+        return;
+    }
+    _squareButtons = squareButtons;
+}
+
 
 #pragma mark - Blur
 


### PR DESCRIPTION
This is needed for when the parent view controller is added as a storyboard item.

The problem is that there is no access to the initializer to set the square buttons (which is what the previous PR did) when the view controller is loaded through the storyboard.
The solution is to make it a public accessible property. Proper usage of this property is the same as other properties and must be set before the parent viewDidLoad gets called.

Please be aware that this is a publicly available repository.

cc @hidrees @Katee @bretthuneycutt 
