### PR TITLE
Changes @import to #import so Cedar unit tests can run.

### DIFF
--- a/THPinViewController/THPinViewController.h
+++ b/THPinViewController/THPinViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Thomas Heß. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import "THPinViewControllerMacros.h"
 
 @class THPinViewController;


### PR DESCRIPTION
Cedar (by the nature of being C-style tests) is incompatible with @import style imports.  Changed the PIN screen project to use #import instead.

cc @Katee @hidrees 
